### PR TITLE
fix(#33): convert q param to local date

### DIFF
--- a/components/date/utils.ts
+++ b/components/date/utils.ts
@@ -51,6 +51,6 @@ export function dateIsToday(date: Date | string): boolean {
   return isSameDate(date, new Date());
 }
 
-export function isValidDate(date: any): date is Date {
+export function isValidDateString(date: any): date is string {
   return typeof date === "string" && !Number.isNaN(new Date(date));
 }

--- a/pages/[city]/[category]/index.tsx
+++ b/pages/[city]/[category]/index.tsx
@@ -8,7 +8,7 @@ import {
 import { GetStaticPaths, GetStaticProps } from "next";
 import { useRouter } from "next/router";
 import CategoryInfo from "../../../components/category-info/category-info";
-import { isValidDate } from "../../../components/date/utils";
+import { isValidDateString } from "../../../components/date/utils";
 import DaysList from "../../../components/days-list/days-list";
 import Layout from "../../../components/layout/layout";
 import { PypOption } from "../../../types";
@@ -34,9 +34,15 @@ export default function Category({
   const router = useRouter();
   const { d: requestedDate, category: categorySlug } = router.query;
 
-  const date = new Date(
-    isValidDate(requestedDate) ? requestedDate : currentDate
-  );
+  let date: Date;
+
+  if (isValidDateString(requestedDate)) {
+    const localRequestedDate = requestedDate.replace(/-/, "/").substr(0, 10);
+    date = new Date(localRequestedDate);
+  } else {
+    date = new Date(currentDate);
+  }
+
   const data = getInfoFromSlug<ICategoryData2>(
     categorySlug as string,
     getCityData2(cityKey, {


### PR DESCRIPTION
When the q para is given with the format `yyyy-mm-dd`, when parsed it is parsed as UTC date and there is a divergence with the local data.

Now previous to parsing it as a date que make sure it is parsed as a local date: `yyyy/mm/dd`.

Fixes #33